### PR TITLE
Alter sbw_einzugsgebiet Filter

### DIFF
--- a/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
+++ b/plugin/teksi_wastewater/interlis/interlis_model_mapping/interlis_exporter_to_intermediate_schema.py
@@ -873,9 +873,14 @@ class InterlisExporterToIntermediateSchema:
         perimeter_query = text(
             """
             WITH geoms AS (
-                SELECT *, ST_ForceCurve((ST_Dump(perimeter_ist)).geom) AS geom 
-                FROM tww_ag6496.sbw_einzugsgebiet
-            )
+             SELECT *, ST_ForceCurve((ST_Dump(perimeter_ist)).geom) AS geom 
+			 FROM tww_ag6496.sbw_einzugsgebiet
+				WHERE ST_NumGeometries(perimeter_ist)>1
+			UNION
+             SELECT *, ST_ForceCurve(ST_GeometryN(perimeter_ist,1)) AS geom 
+			 FROM tww_ag6496.sbw_einzugsgebiet
+				WHERE ST_NumGeometries(perimeter_ist)=1				
+                     )
             SELECT DISTINCT ON (obj_id) obj_id, ST_Area(geom) AS area, geom, ST_GeometryType(geom) as type
             FROM geoms
             ORDER BY obj_id, area DESC;


### PR DESCRIPTION
the changes in #50 altered the geometry type of sbw_einzugsgebiet to MultiSurfaces (before on-the-fly calculated Multipolygons or Polygons). When using ST_Dump on a ST_Multisurface that has only one part, the dump cascades through to the Exterior Ring, resulting in a CoumpoundCurve (in PostGIS 3.0.0). This PR alters the perimeter query to pass CurvePolygons regardless of the structure.